### PR TITLE
feat: initial app structure with recipes feature

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,0 +1,1 @@
+VITE_API_URL=http://localhost:3001

--- a/package.json
+++ b/package.json
@@ -7,11 +7,15 @@
     "dev": "vite",
     "build": "tsc -b && vite build",
     "lint": "eslint .",
-    "preview": "vite preview"
+    "preview": "vite preview",
+    "dev:api": "json-server --watch server/db.json --port 3001",
+    "typecheck": "tsc --noEmit"
   },
   "dependencies": {
     "react": "^19.1.1",
-    "react-dom": "^19.1.1"
+    "react-dom": "^19.1.1",
+    "@tanstack/react-query": "^5.63.0",
+    "zustand": "^4.5.2"
   },
   "devDependencies": {
     "@eslint/js": "^9.33.0",
@@ -24,6 +28,10 @@
     "globals": "^16.3.0",
     "typescript": "~5.8.3",
     "typescript-eslint": "^8.39.1",
-    "vite": "^7.1.2"
+    "vite": "^7.1.2",
+    "tailwindcss": "^3.4.7",
+    "autoprefixer": "^10.4.16",
+    "postcss": "^8.4.35",
+    "json-server": "^0.17.4"
   }
 }

--- a/postcss.config.js
+++ b/postcss.config.js
@@ -1,0 +1,6 @@
+export default {
+  plugins: {
+    tailwindcss: {},
+    autoprefixer: {},
+  },
+};

--- a/server/db.json
+++ b/server/db.json
@@ -1,0 +1,22 @@
+{
+  "recipes": [
+    {
+      "id": 1,
+      "name": "Pâtes à l’ail et au citron",
+      "description": "Rapide, frais, parfait pour un dîner en semaine.",
+      "ingredients": [
+        { "name": "Spaghetti", "quantity": "200g" },
+        { "name": "Ail", "quantity": "2 gousses" },
+        { "name": "Citron", "quantity": "1" }
+      ],
+      "occasions": ["dîner"],
+      "preferences": ["rapide", "budget"],
+      "favorite": true,
+      "createdAt": "2025-08-21T10:00:00Z"
+    }
+  ],
+  "playlist": {
+    "todayRecipeId": 1,
+    "plannedIds": [1]
+  }
+}

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -1,0 +1,5 @@
+import Home from './pages/Home';
+
+export default function App() {
+  return <Home />;
+}

--- a/src/components/RecipeCard.tsx
+++ b/src/components/RecipeCard.tsx
@@ -1,0 +1,14 @@
+import type { Recipe } from '../features/recipes/types';
+
+interface Props {
+  recipe: Recipe;
+}
+
+export default function RecipeCard({ recipe }: Props) {
+  return (
+    <div className="rounded border p-4 shadow">
+      <h2 className="text-lg font-bold">{recipe.name}</h2>
+      <p className="text-sm">{recipe.description}</p>
+    </div>
+  );
+}

--- a/src/features/recipes/api.ts
+++ b/src/features/recipes/api.ts
@@ -1,0 +1,7 @@
+import type { Recipe } from './types';
+
+export async function fetchRecipes(): Promise<Recipe[]> {
+  const res = await fetch(`${import.meta.env.VITE_API_URL}/recipes`);
+  if (!res.ok) throw new Error('Failed to fetch recipes');
+  return res.json();
+}

--- a/src/features/recipes/hooks.ts
+++ b/src/features/recipes/hooks.ts
@@ -1,0 +1,6 @@
+import { useQuery } from '@tanstack/react-query';
+import { fetchRecipes } from './api';
+
+export function useRecipesQuery() {
+  return useQuery({ queryKey: ['recipes'], queryFn: fetchRecipes });
+}

--- a/src/features/recipes/store.ts
+++ b/src/features/recipes/store.ts
@@ -1,0 +1,11 @@
+import { create } from 'zustand';
+
+interface FiltersState {
+  showFavorites: boolean;
+  setShowFavorites: (v: boolean) => void;
+}
+
+export const useRecipeFilters = create<FiltersState>((set) => ({
+  showFavorites: false,
+  setShowFavorites: (v) => set({ showFavorites: v }),
+}));

--- a/src/features/recipes/types.ts
+++ b/src/features/recipes/types.ts
@@ -1,0 +1,15 @@
+export interface Ingredient {
+  name: string;
+  quantity: string;
+}
+
+export interface Recipe {
+  id: number;
+  name: string;
+  description: string;
+  ingredients: Ingredient[];
+  occasions: string[];
+  preferences: string[];
+  favorite: boolean;
+  createdAt: string;
+}

--- a/src/index.css
+++ b/src/index.css
@@ -1,0 +1,3 @@
+@tailwind base;
+@tailwind components;
+@tailwind utilities;

--- a/src/main.tsx
+++ b/src/main.tsx
@@ -1,10 +1,15 @@
-import { StrictMode } from 'react'
-import { createRoot } from 'react-dom/client'
-import './index.css'
-import App from './App.tsx'
+import { StrictMode } from 'react';
+import { createRoot } from 'react-dom/client';
+import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
+import App from './App';
+import './index.css';
+
+const queryClient = new QueryClient();
 
 createRoot(document.getElementById('root')!).render(
   <StrictMode>
-    <p>Hello World</p>
-  </StrictMode>,
-)
+    <QueryClientProvider client={queryClient}>
+      <App />
+    </QueryClientProvider>
+  </StrictMode>
+);

--- a/src/pages/Home.tsx
+++ b/src/pages/Home.tsx
@@ -1,0 +1,29 @@
+import RecipeCard from '../components/RecipeCard';
+import { useRecipesQuery } from '../features/recipes/hooks';
+import { useRecipeFilters } from '../features/recipes/store';
+
+export default function Home() {
+  const { data: recipes, isLoading, error } = useRecipesQuery();
+  const { showFavorites, setShowFavorites } = useRecipeFilters();
+
+  if (isLoading) return <p>Loading...</p>;
+  if (error) return <p>Failed to load recipes</p>;
+
+  const list = showFavorites ? recipes.filter((r) => r.favorite) : recipes;
+
+  return (
+    <div className="p-4">
+      <button
+        className="mb-4 rounded bg-blue-500 px-2 py-1 text-white"
+        onClick={() => setShowFavorites(!showFavorites)}
+      >
+        {showFavorites ? 'Show All' : 'Show Favorites'}
+      </button>
+      <div className="grid gap-4">
+        {list.map((recipe) => (
+          <RecipeCard key={recipe.id} recipe={recipe} />
+        ))}
+      </div>
+    </div>
+  );
+}

--- a/src/utils/sound.ts
+++ b/src/utils/sound.ts
@@ -1,0 +1,11 @@
+export function playClick() {
+  // placeholder for UI click sound
+}
+
+export function playSuccess() {
+  // placeholder for success sound
+}
+
+export function playError() {
+  // placeholder for error sound
+}

--- a/tailwind.config.js
+++ b/tailwind.config.js
@@ -1,0 +1,8 @@
+/** @type {import('tailwindcss').Config} */
+export default {
+  content: ['./index.html', './src/**/*.{ts,tsx}'],
+  theme: {
+    extend: {},
+  },
+  plugins: [],
+};


### PR DESCRIPTION
## Summary
- set up Tailwind CSS, React Query, and Zustand
- scaffold recipe feature with API hooks and state store
- add sample home page displaying recipe list

## Testing
- `pnpm install` *(fails: Error when performing the request to https://registry.npmjs.org/pnpm/-/pnpm-10.5.2.tgz)*
- `npx eslint .`
- `npx tsc --noEmit`


------
https://chatgpt.com/codex/tasks/task_e_68a7863a3108832d9c1c1bdab72b8368