### PR TITLE
chore: improve docker setup and add CI

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -44,13 +44,7 @@ Thumbs.db
 .git/
 .gitignore
 
-# Docker
-Dockerfile
-docker-compose.yml
-.dockerignore
-
 # Documentation
-README.md
 *.md
 
 # Tests

--- a/.github/workflows/docker-publish.yml
+++ b/.github/workflows/docker-publish.yml
@@ -1,0 +1,48 @@
+name: CI
+
+on:
+  push:
+    branches: [main]
+  pull_request:
+    branches: [main]
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Set up Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version: 20
+          cache: 'pnpm'
+
+        # Install dependencies and run checks
+      - name: Install dependencies
+        run: |
+          corepack enable
+          pnpm install --frozen-lockfile
+
+      - name: Lint
+        run: pnpm lint
+
+      - name: Build
+        run: pnpm build
+
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v3
+
+      - name: Log in to Docker Hub
+        uses: docker/login-action@v3
+        with:
+          username: ${{ secrets.DOCKERHUB_USERNAME }}
+          password: ${{ secrets.DOCKERHUB_TOKEN }}
+
+      - name: Build and push Docker image
+        uses: docker/build-push-action@v6
+        with:
+          context: .
+          push: ${{ github.event_name == 'push' }}
+          tags: ${{ secrets.DOCKERHUB_USERNAME }}/eat-day:latest
+

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,62 +1,47 @@
 # Dockerfile multi-stage pour l'application Eat Day
-# Stage 1: Build du frontend React avec Vite
-FROM node:20-alpine AS frontend-builder
 
+# Image de base avec les dépendances système et pnpm
+FROM node:20-alpine AS base
+RUN apk add --no-cache python3 make g++ sqlite \
+    && corepack enable
+
+# ----- Build du frontend -----
+FROM base AS build
 WORKDIR /app
 
-# Copier les fichiers de configuration
-COPY package.json pnpm-lock.yaml ./
-COPY pnpm-workspace.yaml ./
-
-# Installer pnpm et les dépendances
-RUN npm install -g pnpm
+# Installer les dépendances en utilisant le cache Docker
+COPY package.json pnpm-lock.yaml pnpm-workspace.yaml ./
 RUN pnpm install --frozen-lockfile
 
-# Copier le code source
+# Copier le code source et builder le projet
 COPY . .
-
-# Builder l'application frontend
 RUN pnpm run build
 
-# Stage 2: Configuration du runtime avec Node.js
-FROM node:20-alpine AS runtime
-
-# Installer les dépendances système nécessaires pour better-sqlite3
-RUN apk add --no-cache python3 make g++ sqlite
-
+# ----- Runtime -----
+FROM base AS runtime
 WORKDIR /app
 
-# Copier les fichiers de configuration
-COPY package.json pnpm-lock.yaml ./
-COPY pnpm-workspace.yaml ./
-
-# Installer pnpm et les dépendances de production
-RUN npm install -g pnpm
+# Installer uniquement les dépendances de production
+COPY package.json pnpm-lock.yaml pnpm-workspace.yaml ./
 RUN pnpm install --frozen-lockfile --prod
 
-# Copier le serveur backend
-COPY server/ ./server/
+# Copier le backend et le frontend buildé
+COPY server ./server
+COPY --from=build /app/dist ./dist
 
-# Copier les assets buildés du frontend depuis le stage précédent
-COPY --from=frontend-builder /app/dist ./dist
+# Préparer les dossiers nécessaires
+RUN mkdir -p /app/server/uploads /app/data
 
-# Créer les dossiers nécessaires
-RUN mkdir -p /app/server/uploads
-RUN mkdir -p /app/data
-
-# Copier le script de démarrage
-COPY docker-entrypoint.sh ./
+# Script de démarrage
+COPY docker-entrypoint.sh ./docker-entrypoint.sh
 RUN chmod +x docker-entrypoint.sh
 
-# Exposer les ports
-EXPOSE 3001 5173
-
-# Variables d'environnement
+EXPOSE 3001
 ENV NODE_ENV=production
 ENV PORT=3001
 
-# Point de montage pour la base de données (optionnel)
+# Point de montage pour la base de données
 VOLUME ["/app/data"]
 
-# Commande de démarrage
 CMD ["./docker-entrypoint.sh"]
+

--- a/README-Docker.md
+++ b/README-Docker.md
@@ -2,6 +2,8 @@
 
 Ce guide vous explique comment utiliser l'application Eat Day avec Docker.
 
+Une image officielle est automatiquement construite et publiée sur Docker Hub à chaque push sur la branche `main` grâce à GitHub Actions.
+
 ## 📋 Prérequis
 
 - Docker installé sur votre système

--- a/docker-entrypoint.sh
+++ b/docker-entrypoint.sh
@@ -3,7 +3,7 @@
 # Script de démarrage pour l'application Eat Day
 # Lance le serveur backend qui sert aussi le frontend
 
-set -e
+set -eu
 
 echo "🚀 Démarrage de l'application Eat Day..."
 
@@ -39,3 +39,4 @@ echo "🌐 Démarrage du serveur sur le port $PORT..."
 
 # Démarrer le serveur Node.js
 exec node server/index.js
+


### PR DESCRIPTION
## Summary
- streamline Dockerfile and entrypoint
- clean dockerignore and docs
- add GitHub Actions to lint, build and publish to Docker Hub

## Testing
- `pnpm lint` *(fails: fetch failed to download pnpm)*
- `pnpm build` *(fails: fetch failed to download pnpm)*
